### PR TITLE
Fix some URLs containing em-dashes

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1621,6 +1621,7 @@ information_resources:
     status: released
     name: Gene Ontology Causal Activity Model Annotations
     xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/GO-CAM
       - https://github.com/NCATSTranslator/Translator-All/wiki/GO%E2%80%90CAM
     synonym:
       - GO-CAM

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1622,7 +1622,6 @@ information_resources:
     name: Gene Ontology Causal Activity Model Annotations
     xref:
       - https://github.com/NCATSTranslator/Translator-All/wiki/GO-CAM
-      - https://github.com/NCATSTranslator/Translator-All/wiki/GO%E2%80%90CAM
     synonym:
       - GO-CAM
     knowledge level: curated
@@ -1644,7 +1643,7 @@ information_resources:
     knowledge level: curated
     agent type: not_provided
     xref:
-      - https://github.com/NCATSTranslator/Translator-All/wiki/GO%E2%80%90Plus
+      - https://github.com/NCATSTranslator/Translator-All/wiki/GO-Plus
   - id: infores:human-goa
     status: released
     name: Human Gene Ontology Annotations
@@ -2036,7 +2035,7 @@ information_resources:
     status: released
     name: LOINC (from UMLS)
     xref:
-      - https://github.com/NCATSTranslator/Translator-All/wiki/LOINC-%E2%80%90-UMLS
+      - https://github.com/NCATSTranslator/Translator-All/wiki/LOINC-from-UMLS
     knowledge level: curated
     agent type: not_provided
   - id: infores:mp
@@ -2811,7 +2810,7 @@ information_resources:
     status: released
     name: RTX KG2
     xref:
-      - https://github.com/NCATSTranslator/Translator-All/wiki/RTX%E2%80%90KG2
+      - https://github.com/NCATSTranslator/Translator-All/wiki/RTX-KG2
     synonym:
       - Rtx-kg2
     knowledge level: curated


### PR DESCRIPTION
Some URLs inadvertently include em-dashes, and so don't resolve on our wiki. This PR changes that back to normal ASCII dash characters, which work correctly.