### PR TITLE
Update knolwedge type of bte entry to 'predicted'

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -545,7 +545,7 @@ information_resources:
       - https://github.com/NCATSTranslator/Translator-All/wiki/BioThings-Explorer-(BTE)
     synonym:
       - BTE
-    knowledge level: other
+    knowledge level: predicted
     agent type: not_provided
   - id: infores:service-provider-trapi
     status: released


### PR DESCRIPTION
Changed knowledge type of bte infores entry from 'other' to 'predicted' - as needed by the UI to correctly collapse diagrams of inferred answer edges. 