### PR TITLE
fail tests if URLs are invalid

### DIFF
--- a/.github/workflows/pr-verify-pull-request.yaml
+++ b/.github/workflows/pr-verify-pull-request.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run tests, codespell, and yamllint
         run: |
-          make test_pr
+          make test
 
       - name: Validate YAML file
         run: yamllint -c .yamllint-config src/information_resource_registry/schema/information_resource_registry.yaml

--- a/.github/workflows/push-main-regenerate-artifacts.yaml
+++ b/.github/workflows/push-main-regenerate-artifacts.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           poetry install
           make gen-project
-          make test_pr
+          make test
           make sankey
           make gendoc
           if [ $? -eq 0 ]; then

--- a/src/information_resource_registry/validation/check_urls.py
+++ b/src/information_resource_registry/validation/check_urls.py
@@ -113,8 +113,8 @@ def main():
                 # Update the progress bar
                 pbar.update(1)
 
-    # if invalid_resource_urls:
-    #     raise ValueError(f"Invalid URLs found: {invalid_resource_urls}")
+    if invalid_resource_urls:
+        raise ValueError(f"Invalid URLs found: {invalid_resource_urls}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds the URL resolution back into the main PR-check actions with some parallelization to decrease the time it takes to check all the URLs.  

as of this PR, all URLs/sources are resolving and/or deprecated.