### PR TITLE
Add tsv/json/jsonl (& yaml) release artifacts

### DIFF
--- a/.github/workflows/release-upload-artifacts.yaml
+++ b/.github/workflows/release-upload-artifacts.yaml
@@ -1,0 +1,38 @@
+---
+name: Upload Release Artifacts
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  upload-artifacts:
+    name: Create and upload release artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Generate release artifacts
+        run: make create_release_extras
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release-output/

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+release-output

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SHELL := bash
 
 RUN = poetry run
 DOCDIR = docs
+RELEASE_TMPDIR = release-output
 
 .PHONY: all clean
 
@@ -35,6 +36,14 @@ install:
 
 all: site
 site: gen-project gendoc
+
+create_release_extras:
+	mkdir -p ${RELEASE_TMPDIR}
+	cp infores_catalog.yaml ${RELEASE_TMPDIR}/infores_catalog.yaml
+	$(RUN) linkml-convert -s src/information_resource_registry/schema/information_resource_registry.yaml -f yaml -t tsv infores_catalog.yaml > ${RELEASE_TMPDIR}/infores_catalog.tsv
+	$(RUN) linkml-convert -s src/information_resource_registry/schema/information_resource_registry.yaml -f yaml -t json infores_catalog.yaml > ${RELEASE_TMPDIR}/infores_catalog.json
+	jq -c '.information_resources[]' ${RELEASE_TMPDIR}/infores_catalog.json > ${RELEASE_TMPDIR}/infores_catalog.jsonl
+
 
 test_pr:
 	$(RUN) linkml-validate infores_catalog.yaml -s src/information_resource_registry/schema/information_resource_registry.yaml

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1666,7 +1666,7 @@ information_resources:
       - infores:automat-isb-EHRMLA-data
       - infores:connections-hypothesis
       - infores:multiomics-ctkp
-      - infores:text-mining-provider targeted
+      - infores:text-mining-provider-targeted
       - infores:service-provider-tmkp-targeted
       - infores:openpredict
       - infores:service-provider-aeolus
@@ -4878,10 +4878,12 @@ information_resources:
     xref:
       - https://github.com/NCATSTranslator/Translator-All/wiki/Automat
   - id: infores:biothings-mabs
+    status: released
     consumes:
       - infores:sepid_mab
     consumed_by:
       - infores:service-provider-trapi
   - id: infores:sepid_mab
+    status: released
     consumed_by:
       - infores:biothings-mabs

--- a/linkml.Makefile
+++ b/linkml.Makefile
@@ -46,3 +46,4 @@ gen-project: $(PYMODEL)
 	$(RUN) gen-pydantic --version 2 src/information_resource_registry/schema/information_resource_registry.yaml > $(PYMODEL)/pydanticmodel_v2.py
 	$(RUN) gen-owl --mergeimports --no-metaclasses --no-type-objects --add-root-classes --mixins-as-expressions src/information_resource_registry/schema/information_resource_registry.yaml > $(DEST)/owl/information_resource.owl.ttl
 	$(MAKE) infores
+


### PR DESCRIPTION
This adds a makefile target & github action to create tsv/json/jsonlines of infores catalog

Uploads them along with yaml to be present as release artifacts

Also fixes a few problems in the data that failed validation and prevented linkml-convert from running
