### PR TITLE
Get rid of redundant "infores" in filename for md pages

### DIFF
--- a/src/doc-templates/overview.md.jinja2
+++ b/src/doc-templates/overview.md.jinja2
@@ -5,5 +5,5 @@
 | ID | Name | Status | Knowledge Level | Description |
 |----|------|--------|-----------------|-------------|
 {%- for res in resources %}
-| [{{ res.id }}](resources/{{ res.id | replace(':','_') }}.md) | {{ res.name }} | {{ res.status }} | {{ res.knowledge_level }} | {{ res.description[:50] ~ ('...' if res.description and res.description|length > 50 else '') if res.description else 'N/A' }} |
+| [{{ res.id }}](resources/{{ res.id | replace('infores:','') }}.md) | {{ res.name }} | {{ res.status }} | {{ res.knowledge_level }} | {{ res.description[:50] ~ ('...' if res.description and res.description|length > 50 else '') if res.description else 'N/A' }} |
 {%- endfor %}

--- a/utils/generate-registry.py
+++ b/utils/generate-registry.py
@@ -32,7 +32,7 @@ def generate_docs(yaml_file, output_dir, overview_template, detail_template):
 
     for resource in resources:
         detail_content = detail_tmpl.render(resource=resource)
-        filename = resource['id'].replace(':', '_') + '.md'
+        filename = resource['id'].replace('infores:', '') + '.md'
         with open(detail_dir / filename, 'w') as f:
             f.write(detail_content)
 


### PR DESCRIPTION
cc @sierra-moxon to change the URLs of the actual resource pages from currently

https://biolink.github.io/information-resource-registry/resources/infores_rnacentral/

to

https://biolink.github.io/information-resource-registry/resources/rnacentral/

