### PR TITLE
Add Retriever

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -4072,6 +4072,19 @@ information_resources:
     consumed_by:
       - infores:ars
     consumes:
+      - infores:retriever
+  - id: infores:retriever
+    status: released
+    name: Retriever
+    xref:
+      - https://github.com/BioPack-team/retriever
+    knowledge_level: mixed
+    agent_type: not_provided
+    description: >-
+      Retriever: The TRAPI access layer to Tier 0/1/2 KGs.
+    consumed_by:
+      - infores:shepherd-aragorn
+    consumes:
       - infores:automat-robokopkg
   - id: infores:sider
     status: released


### PR DESCRIPTION
Note I used `knowledge_level: mixed` as Retriever itself is not a knowledge source, and the respective sources it will draw from should cover many of the other knowledge levels.