### PR TITLE
Fix line breaks in resource names for readability

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3788,8 +3788,8 @@ information_resources:
     consumed_by:
       - infores:rtx-kg2
   - status: released
-    name: National Center for Advancing Translational Science Biomedical Data Translator Autonomous
-        Relay System
+    name: National Center for Advancing Translational Science Biomedical Data Translator
+        Autonomous Relay System
     id: infores:ncats-ars
     xref:
       - https://github.com/NCATSTranslator/Translator-All/wiki/Autonomous-Relay-System-(ARS)
@@ -3834,8 +3834,8 @@ information_resources:
     consumed_by:
       - infores:rtx-kg2
   - status: deprecated
-    name: North Carolina Department of Environmental Quality Concentrated Animal Feeding Operations
-        Exposures Data
+    name: North Carolina Department of Environmental Quality Concentrated Animal Feeding
+        Operations Exposures Data
     id: infores:ncdeq-cafo-exposures-data
     knowledge_level: knowledge_assertion
     agent_type: not_provided
@@ -4008,8 +4008,8 @@ information_resources:
     consumed_by:
       - infores:cohd
   - status: released
-    name: Observational Medical Outcomes Partnership Observational Health Data Sciences and
-        Informatics API
+    name: Observational Medical Outcomes Partnership Observational Health Data Sciences 
+        and Informatics API
     id: infores:omop-ohdsi-api
     xref:
       - https://chime.ucsf.edu/observational-medical-outcomes-partnership-omop
@@ -4542,7 +4542,8 @@ information_resources:
     consumed_by:
       - infores:unsecret-agent
   - status: deprecated
-    name: ROBOKOP (Reasoning Over Biomedical Objects linked in Knowledge-Oriented Pathway)
+    name: ROBOKOP (Reasoning Over Biomedical Objects linked in Knowledge-Oriented 
+        Pathway)
     id: infores:robokop-kp
     xref:
       - http://robokop.renci.org
@@ -5308,7 +5309,8 @@ information_resources:
     knowledge_level: knowledge_assertion
     agent_type: not_provided
   - status: deprecated
-    name: United States Environmental Protection Agency Airborne Pollutant Exposures Data
+    name: United States Environmental Protection Agency Airborne Pollutant Exposures 
+        Data
     id: infores:us-epa-airborne-pollutant-exposures-data
     knowledge_level: knowledge_assertion
     agent_type: not_provided


### PR DESCRIPTION
Adjusted line breaks in several long 'name' fields within infores_catalog.yaml to improve readability and maintain consistent formatting.