### PR TITLE
Fix indentation for postconditions in YAML schema

### DIFF
--- a/src/information_resource_registry/schema/information_resource_registry.yaml
+++ b/src/information_resource_registry/schema/information_resource_registry.yaml
@@ -57,7 +57,7 @@ classes:
           slot_conditions:
             status:
               equals_string: "released"
-      - postconditions:
+        postconditions:
           slot_conditions:
             knowledge_level:
               required: true


### PR DESCRIPTION
Fixes #108 

Corrected the indentation of the postconditions block under slot_conditions to ensure proper schema parsing and validation.