### PR TITLE
Add infores entries for MPIDB, Molecular Connections, and NTNU

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3796,6 +3796,17 @@ information_resources:
     knowledge_level: knowledge_assertion
     agent_type: not_provided
   - status: released
+    name: Molecular Connections
+    id: infores:molecular-connections
+    xref:
+      - http://www.molecularconnections.com
+    description: >-
+      In silico discovery-services company specializing in drug discovery informatics that
+      contributes curated molecular interaction data pro bono to the IMEx Consortium.
+      (PSI-MI: MI:1263)
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  - status: released
     name: Molecular Data Provider for NCATS Biomedical Translator Reasoners
     id: infores:molepro
     xref:
@@ -3922,6 +3933,17 @@ information_resources:
       phenotypes
     knowledge_level: knowledge_assertion
     agent_type: not_provided
+  - status: released
+    name: Microbial Protein Interaction Database (MPIDB)
+    id: infores:mpidb
+    xref:
+      - https://www.ebi.ac.uk/intact/
+    description: >-
+      Collection of physical protein-protein interactions in prokaryotes. As of 2013 the
+      original MPIDB database is no longer active; all IMEx-curated MPIDB content was
+      imported into and is now maintained by IntAct. (PSI-MI: MI:0903)
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
   - status: released
     name: Molecular Signatures Database
     id: infores:msigdb
@@ -4266,6 +4288,16 @@ information_resources:
       - https://github.com/NCATSTranslator/Translator-All/wiki/nSides
     knowledge_level: knowledge_assertion
     agent_type: not_provided
+  - status: released
+    name: Norwegian University of Science and Technology (NTNU)
+    id: infores:ntnu
+    xref:
+      - https://www.ntnu.no/
+    description: >-
+      NTNU-affiliated curators contributing molecular interaction annotations to the IMEx
+      Consortium via IntAct. (PSI-MI: MI:1264)
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
   - status: released
     name: Ontology of Biological Attributes
     id: infores:oba


### PR DESCRIPTION
## Summary

This PR adds three new `information_resources` entries to `infores_catalog.yaml` for IntAct-associated source databases that appear in the `Source database(s)` column of the IntAct MITAB export but do not yet have infores CURIEs in the catalog:

- `infores:mpidb` — Microbial Protein Interaction Database (PSI-MI: MI:0903)
- `infores:molecular-connections` — Molecular Connections (PSI-MI: MI:1263)
- `infores:ntnu` — Norwegian University of Science and Technology (PSI-MI: MI:1264)

Each entry was drafted using the format of comparable existing IntAct-associated sources already in the catalog (e.g., `infores:hpidb`, `infores:mint`, `infores:mbinfo`, `infores:bhf-ucl`), and cross-referenced against the PSI-MI CV term definitions on OLS.

## Motivation

These CURIEs are needed by downstream NCATS Translator ingests — specifically the IntAct RIG — so that the full set of supporting data sources reported by IntAct can be attributed with valid `infores` identifiers rather than being omitted.

## Changes

- 3 new entries appended to `infores_catalog.yaml` at their alphabetical positions
- No existing entries modified

## Test plan

- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] All 3 new IDs present, no duplicate IDs across catalog (495 total entries)
- [ ] LinkML validation (deferring to maintainer CI)